### PR TITLE
Add context to unresolvable path parameter error message.

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -234,7 +234,7 @@ def validate_unresolvable_path_params(path_name, path_params):
     msg = "Path Parameter used is not defined"
     for path in get_path_params_from_url(path_name):
         if path not in path_params:
-            raise SwaggerValidationError("%s: %s" % (msg, path))
+            raise SwaggerValidationError("%s: %s (in path %s)" % (msg, path, path_name))
 
 
 def is_ref(spec_dict):


### PR DESCRIPTION
If a path is used but includes an undefined parameter, `swagger_spec_validator` throws an error:

```
swagger_spec_validator.common.SwaggerValidationError: Path Parameter used is not defined: id
```

This error doesn't tell the user anything about _which_ path is affected, and when multiple paths have the same parameter name, is effectively useless.

This PR adds context to the error message so users can identify which full path is causing the error:

```
swagger_spec_validator.common.SwaggerValidationError: Path Parameter used is not defined: id (in path /foo/{id}/bar/{id_b}/baz)
```